### PR TITLE
Fix an typo in args

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,4 +1,4 @@
-name: Build Package and Publish to TestPyPI & PyPI
+name: Build and Publish Package
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build Package and Publish to TestPyPI & PyPI
+    name: Build and Publish Package
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
@@ -23,7 +23,7 @@ jobs:
         with:
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
-      - name: Publish package to TestPyPI
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests on Various Python Versions
+name: Run Tests
 
 on: push
 
@@ -15,5 +15,5 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Run Tests on ${{ matrix.python }}
+      - name: Run Tests
         run: ./tests.py

--- a/accesslog/__main__.py
+++ b/accesslog/__main__.py
@@ -76,8 +76,8 @@ def main():
     except ValueError as e:
         sys.exit(e)
 
-    if args.validate_fields == ["all"]:
-        args.validate_fields = CLParser.validators.keys()
+    if args.valid == ["all"]:
+        args.valid = CLParser.validators.keys()
 
     try:
         clp = CLParser(origtime_format=args.origtime, non_empty_fields=args.nonempty, validate_fields=args.valid, field_matchers=args.match)


### PR DESCRIPTION
Renamed `args.validate_fields` to `args.valid` due to simplification in args.