### PR TITLE
Fix local import issue when run from the folder

### DIFF
--- a/accesslog/__main__.py
+++ b/accesslog/__main__.py
@@ -9,7 +9,7 @@ import sys
 
 try:
     from .clparser import CLParser
-except ModuleNotFoundError:
+except (ImportError, ModuleNotFoundError):
     from clparser import CLParser
 
 


### PR DESCRIPTION
```
$ python accesslog-parser/accesslog
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "accesslog-parser/accesslog/__main__.py", line 11, in <module>
    from .clparser import CLParser
ImportError: attempted relative import with no known parent package
```